### PR TITLE
using '_' instead of 'hysds_' for spec parameters

### DIFF
--- a/notebook_pge_wrapper/execute_notebook.py
+++ b/notebook_pge_wrapper/execute_notebook.py
@@ -48,7 +48,7 @@ def _build_notebook_params(nb, ctx):
 
     params = {}
     for k, p in nb_params.items():
-        if k.startswith('hysds_'):
+        if k.startswith('hysds_') or k.startswith('_'):
             continue
         if ctx.get(k) is not None:  # if key is found in _context.json then populate params dict with value
             params[k] = ctx[k]

--- a/notebook_pge_wrapper/spec_generator.py
+++ b/notebook_pge_wrapper/spec_generator.py
@@ -121,7 +121,7 @@ def _generate_hysdsio_params(nb_name):  # private method
     params = []
 
     for k, p in nb_params.items():
-        if k.startswith('hysds_'):
+        if k.startswith('hysds_') or k.startswith('_'):
             continue
 
         param_type = p['inferred_type_name']
@@ -156,10 +156,15 @@ def extract_hysds_specs(nb_name):
 
     hysds_specs = {}
     for k, p in nb_params.items():
-        if not k.startswith('hysds_'):
+        if not k.startswith('hysds_') and not k.startswith('_'):
             continue
 
-        k = k.replace('hysds_', '')
+        if k.startswith('hysds_'):
+            k = k.replace('hysds_', '')
+            print("DEPRECATION WARNING: please prefix parameter (%s) with '_' instead of 'hysds_'" % k)
+        else:
+            k = k[1:]
+
         default_value = p['default']
         try:
             hysds_specs[k] = ast.literal_eval(default_value)
@@ -236,7 +241,7 @@ def generate_job_spec(time_limit=__DEFAULT_TIME_LIMIT, soft_time_limit=__DEFAULT
     params = []
 
     for key in nb_params:
-        if key.startswith('hysds_'):
+        if key.startswith('hysds_') or key.startswith('_'):
             continue
 
         params.append({

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='notebook_pge_wrapper',
-    version='1.0.1',
+    version='1.0.2',
     long_description='Library to generate hysds_io and job_specs for Jupyter notebooks',
     packages=find_packages(),
     include_package_data=True,

--- a/test/notebook_pges/test.ipynb
+++ b/test/notebook_pges/test.ipynb
@@ -22,12 +22,12 @@
     "h: Dict = {'a': 1, \"b\": 2, 'c': 3}\n",
     "\n",
     "# hysds specs\n",
-    "hysds_time_limit = 57389\n",
-    "hysds_soft_time_limit = 4738\n",
-    "hysds_disk_usage = \"10GB\"\n",
-    "hysds_submission_type = \"iteration\"\n",
-    "hysds_required_queue = \"test_queue-worker\"\n",
-    "hysds_label = \"TEST LABEL FOR HYSDS_IOS\""
+    "_time_limit = 57389\n",
+    "_soft_time_limit = 4738\n",
+    "_disk_usage = \"10GB\"\n",
+    "_submission_type = \"iteration\"\n",
+    "_required_queue = \"test_queue-worker\"\n",
+    "_label = \"TEST LABEL FOR HYSDS_IOS\""
    ]
   },
   {

--- a/test/notebook_pges/test2.ipynb
+++ b/test/notebook_pges/test2.ipynb
@@ -15,7 +15,7 @@
     "c = 10.2553  # type: float\n",
     "\n",
     "# hysds specs\n",
-    "hysds_command = \"python custom_wrapper_script.py\""
+    "_command = \"python custom_wrapper_script.py\""
    ]
   }
  ],


### PR DESCRIPTION
keeping `hysds_` for backwards compatibility
related ticket: https://hysds-core.atlassian.net/browse/HC-352